### PR TITLE
disable contradictory warning on clang

### DIFF
--- a/tfc_config.cmake
+++ b/tfc_config.cmake
@@ -12,6 +12,12 @@ if (CCACHE_FOUND)
 endif ()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Weverything can include contradictory warnings, so we need to disable one of them
+  # We require all switch cases to be handled, so we don't need default case
+  # More info here: https://github.com/llvm/llvm-project/issues/81354
+  add_compile_options(
+    -Wno-switch-default
+  )
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options( -flto=thin )
   endif()

--- a/toolchains/x64-linux-clang.cmake
+++ b/toolchains/x64-linux-clang.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_SYSTEM_PROCESSOR x64)
-set(COMPILER_MINIMUM_VERSION 17)
+set(COMPILER_MINIMUM_VERSION 18)
 
 if (EXISTS "/cpproot/bin/clang")
 #  TODO compile libc in container

--- a/toolchains/x64-linux-clang.cmake
+++ b/toolchains/x64-linux-clang.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_SYSTEM_PROCESSOR x64)
-set(COMPILER_MINIMUM_VERSION 18)
+set(COMPILER_MINIMUM_VERSION 17)
 
 if (EXISTS "/cpproot/bin/clang")
 #  TODO compile libc in container


### PR DESCRIPTION
new warning introduced in llvm 18 is contradictory to previous warning, need to disable one of them otherwise the code does not compile